### PR TITLE
Improve DB performance

### DIFF
--- a/server-worker/db/procs/calendar.sql
+++ b/server-worker/db/procs/calendar.sql
@@ -1,5 +1,5 @@
 CREATE TABLE calendar (
-  id int NOT NULL IDENTITY(1,1) PRIMARY KEY,
+  id int NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED,
   service_id nvarchar(100) NOT NULL,
   monday bit NOT NULL,
   tuesday bit NOT NULL,
@@ -10,7 +10,10 @@ CREATE TABLE calendar (
   sunday bit NOT NULL,
   start_date date NOT NULL,
   end_date date NOT NULL,
-)
+);
 
-CREATE NONCLUSTERED INDEX id_Calendar
-ON calendar (service_id)
+CREATE CLUSTERED INDEX IX_Calendar_service_id
+ON calendar (service_id);
+
+CREATE NONCLUSTERED INDEX IX_Calendar_start_date_end_date
+ON calendar (start_date, end_date);

--- a/server-worker/db/procs/calendar_dates.sql
+++ b/server-worker/db/procs/calendar_dates.sql
@@ -1,9 +1,12 @@
 CREATE TABLE calendar_dates (
-  id int NOT NULL IDENTITY(1,1) PRIMARY KEY,
+  id int NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED,
   service_id nvarchar(100) NOT NULL,
   date date NOT NULL,
   exception_type int NOT NULL,
-)
+);
 
-CREATE NONCLUSTERED INDEX id_Calendar_Dates
-ON calendar_dates (service_id, date)
+CREATE CLUSTERED INDEX IX_Calendar_Dates_service_id
+ON calendar_dates (service_id);
+
+CREATE NONCLUSTERED INDEX IX_Calendar_Dates_service_id_date
+ON calendar_dates (service_id, date);

--- a/server-worker/db/procs/routes.sql
+++ b/server-worker/db/procs/routes.sql
@@ -1,5 +1,5 @@
 CREATE TABLE routes (
-  id int NOT NULL IDENTITY(1,1) PRIMARY KEY,
+  id int NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED,
   route_id nvarchar(100) NOT NULL,
   agency_id nvarchar(100),
   route_short_name nvarchar(50) NOT NULL,
@@ -10,4 +10,7 @@ CREATE TABLE routes (
   route_color nvarchar(50),
   route_text_color nvarchar(50),
   CONSTRAINT uc_Routes UNIQUE (route_id)
-)
+);
+
+CREATE CLUSTERED INDEX IX_Routes_route_id
+ON routes (route_id);

--- a/server-worker/db/procs/stop_times.sql
+++ b/server-worker/db/procs/stop_times.sql
@@ -1,5 +1,5 @@
 CREATE TABLE stop_times (
-  id int NOT NULL IDENTITY(1,1) PRIMARY KEY,
+  id int NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED,
   trip_id nvarchar(100) NOT NULL,
   arrival_time time(0) NOT NULL,
   departure_time time(0) NOT NULL,
@@ -12,15 +12,15 @@ CREATE TABLE stop_times (
   drop_off_type int,
   shape_dist_traveled float,
   timepoint int
-)
+);
 
-CREATE NONCLUSTERED INDEX id_Stop_Times
+CREATE CLUSTERED INDEX IX_Stop_Times_trip_id_stop_id
+ON stop_times (trip_id, stop_id);
+
+CREATE NONCLUSTERED INDEX IX_Stop_Times_stop_id_departure_time
 ON stop_times (stop_id, departure_time)
-INCLUDE (trip_id, departure_time_24, stop_sequence)
+INCLUDE (trip_id, departure_time_24, stop_sequence);
 
-CREATE NONCLUSTERED INDEX id_Stop_Times_Trips
-ON stop_times (trip_id)
-
-CREATE NONCLUSTERED INDEX id_Stop_Times_Times
-ON [dbo].[stop_times] ([departure_time])
-INCLUDE ([trip_id],[departure_time_24],[stop_id],[stop_sequence])
+CREATE NONCLUSTERED INDEX IX_Stop_Times_departure_time
+ON stop_times (departure_time)
+INCLUDE (trip_id,departure_time_24,stop_id,stop_sequence);

--- a/server-worker/db/procs/stops.sql
+++ b/server-worker/db/procs/stops.sql
@@ -1,5 +1,5 @@
 CREATE TABLE stops (
-  id int NOT NULL IDENTITY(1,1) PRIMARY KEY,
+  id int NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED,
   stop_id nvarchar(100) NOT NULL,
   stop_code nvarchar(100),
   stop_name nvarchar(100) NOT NULL,
@@ -13,6 +13,10 @@ CREATE TABLE stops (
   stop_timezone nvarchar(100),
   wheelchair_boarding int,
   CONSTRAINT uc_Stops UNIQUE (stop_id)
-)
-CREATE NONCLUSTERED INDEX id_Stops
-ON stops (stop_code)
+);
+
+CREATE CLUSTERED INDEX IX_Stops_stop_id
+ON stops (stop_id);
+
+CREATE NONCLUSTERED INDEX IX_Stops_stop_code
+ON stops (stop_code);

--- a/server-worker/db/procs/trips.sql
+++ b/server-worker/db/procs/trips.sql
@@ -1,5 +1,5 @@
 CREATE TABLE trips (
-  id int NOT NULL IDENTITY(1,1) PRIMARY KEY,
+  id int NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED,
   route_id nvarchar(100) NOT NULL,
   service_id nvarchar(100) NOT NULL,
   trip_id nvarchar(100) NOT NULL,
@@ -11,4 +11,13 @@ CREATE TABLE trips (
   wheelchair_accessible int,
   bikes_allowed int,
   CONSTRAINT uc_Trips UNIQUE (trip_id)
-)
+);
+
+CREATE CLUSTERED INDEX IX_Trips_trip_id
+ON trips (trip_id);
+
+CREATE NONCLUSTERED INDEX IX_Trips_route_id
+ON trips (route_id);
+
+CREATE NONCLUSTERED INDEX IX_Trips_service_id
+ON trips (service_id);


### PR DESCRIPTION
Tweaking indexes for better DB performance.
It's far from perfect, but this is a good start and a vast improvement.

Summary:
* Modified identity key (id) to be non-clustered
* Added clustered indexes on semantic key columns
* Add non-clustered indxes on columns included in JOIN/WHERE clauses
* Improved naming convention of index names